### PR TITLE
Dev/math/update extended splash screen uno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
 * Support for Android 11 (March, 2021)
 
 ### Changed
@@ -16,6 +19,8 @@ Update Android target to 10.0
 ### Deprecated
 
 ### Removed
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 
 ### Fixed
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -6,13 +6,13 @@
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
-  value: 5.8.1
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 17.1.0
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -21,7 +21,7 @@ variables:
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.2.0
+next-version: 0.3.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
+++ b/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362;net461</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041;net472</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<Authors>nventive</Authors>
@@ -21,6 +21,8 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="3.1.0-beta.84" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Uno.Core" Version="4.0.1" />
+		<PackageReference Include="Uno.UI" Version="4.0.7" />
 	</ItemGroup>
 </Project>

--- a/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
+++ b/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
@@ -23,6 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.UI" Version="4.0.7" />
+		<PackageReference Include="Uno.UI" Version="4.0.13" />
 	</ItemGroup>
 </Project>

--- a/src/library/ExtendedSplashScreen.Uno/Implementations/ExtendedSplashScreen.Windows.cs
+++ b/src/library/ExtendedSplashScreen.Uno/Implementations/ExtendedSplashScreen.Windows.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
-using Uno.Logging;
 using Windows.ApplicationModel.Activation;
 using Windows.Graphics.Display;
 using Windows.UI;

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
@@ -22,6 +22,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\ExtendedSlashScreen.Uno.Samples.Shared\Strings</ResourcesDirectory>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
@@ -18,7 +18,7 @@
     <AndroidUseAapt2>false</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\ExtendedSlashScreen.Uno.Samples.Shared\Strings</ResourcesDirectory>
@@ -64,8 +64,8 @@
     <PackageReference Include="Uno.Core">
       <Version>4.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.0.7" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="4.1.9" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
@@ -61,11 +61,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.1.0-beta.84" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-beta.84" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+    <PackageReference Include="Uno.Core">
+      <Version>4.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -103,6 +106,4 @@
   </ItemGroup>
   <Import Project="..\ExtendedSlashScreen.Uno.Samples.Shared\ExtendedSlashScreen.Uno.Samples.Shared.projitems" Label="Shared" Condition="Exists('..\ExtendedSlashScreen.Uno.Samples.Shared\ExtendedSlashScreen.Uno.Samples.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <!-- This will force the generation of the APK when not building inside visual studio -->
-  <Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''" />
 </Project>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/ExtendedSlashScreen.Uno.Samples.Droid.csproj
@@ -33,6 +33,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/Properties/AndroidManifest.xml
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="ExtendedSlashScreen.Uno.Samples" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+  <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="31" />
   <application android:label="ExtendedSlashScreen.Uno.Samples"></application>
 </manifest>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -37,6 +38,10 @@ namespace ExtendedSlashScreen.Uno.Samples
 
 		public Shell Shell { get; private set; }
 
+		public Window CurrentWindow => Windows.UI.Xaml.Window.Current;
+
+		public Activity ShellActivity { get; } = new Activity(nameof(Shell));
+
 		/// <summary>
 		/// Invoked when the application is launched normally by the end user.  Other entry points
 		/// will be used such as when the application is launched to open a specific file.
@@ -49,17 +54,22 @@ namespace ExtendedSlashScreen.Uno.Samples
 			{
 				// this.DebugSettings.EnableFrameRateCounter = true;
 			}
-#endif
-            Shell = Windows.UI.Xaml.Window.Current.Content as Shell;
+# endif
+			Shell = CurrentWindow.Content as Shell;
 
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (Shell == null)
-            {
-				Windows.UI.Xaml.Window.Current.Content = Shell = new Shell(e);
+			var isFirstLaunch = Shell == null;
+
+			if (isFirstLaunch)
+			{
+				ShellActivity.Start();
+
+				CurrentWindow.Content = Shell = new Shell(e);
+
+				ShellActivity.Stop();
 			}
 
-			Windows.UI.Xaml.Window.Current.Activate();
+			CurrentWindow.Activate();
+			Shell = Windows.UI.Xaml.Window.Current.Content as Shell;
 
 			if (Shell.NavigationFrame.Content == null)
 			{

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
@@ -98,11 +98,11 @@ namespace ExtendedSlashScreen.Uno.Samples
         /// <param name="factory"></param>
         static void ConfigureFilters(ILoggerFactory factory)
         {
-            factory
-                .WithFilter(new FilterLoggerSettings
-                    {
-                        { "Uno", LogLevel.Warning },
-                        { "Windows", LogLevel.Warning },
+			factory
+				.WithFilter(new FilterLoggerSettings
+					{
+						{ "Uno", LogLevel.Warning },
+						{ "Windows", LogLevel.Warning },
 
 						// Debug JS interop
 						// { "Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug },
@@ -137,12 +137,7 @@ namespace ExtendedSlashScreen.Uno.Samples
 						// { "Windows.UI.Xaml.Controls.BufferViewCache", LogLevel.Debug }, //Android
 						// { "Windows.UI.Xaml.Controls.VirtualizingPanelGenerator", LogLevel.Debug }, //WASM
 					}
-                )
-#if DEBUG
-				.AddConsole(LogLevel.Debug);
-#else
-                .AddConsole(LogLevel.Information);
-#endif
+				);
         }
     }
 }

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/App.xaml.cs
@@ -69,7 +69,6 @@ namespace ExtendedSlashScreen.Uno.Samples
 			}
 
 			CurrentWindow.Activate();
-			Shell = Windows.UI.Xaml.Window.Current.Content as Shell;
 
 			if (Shell.NavigationFrame.Content == null)
 			{

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/Shell.xaml.cs
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.Shared/Shell.xaml.cs
@@ -27,7 +27,9 @@ namespace ExtendedSlashScreen.Uno.Samples
 
 			Instance = this;
 
-			AppExtendedSplashScreen.SplashScreen = e.SplashScreen;
+#if WINDOWS_UWP
+			AppExtendedSplashScreen.SplashScreen = e?.SplashScreen;
+#endif
 		}
 
 		public IExtendedSplashScreen ExtendedSplashScreen => this.AppExtendedSplashScreen;

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.UWP/ExtendedSlashScreen.Uno.Samples.UWP.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.UWP/ExtendedSlashScreen.Uno.Samples.UWP.csproj
@@ -10,9 +10,11 @@
 			-->
       <Version>6.2.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Core" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
+    <PackageReference Include="Uno.Core">
+      <Version>4.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -24,7 +26,7 @@
     <AssemblyName>ExtendedSlashScreen.Uno.Samples</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
@@ -120,8 +120,8 @@
     <PackageReference Include="Uno.Core">
       <Version>4.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.0.7" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="4.1.9" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
   </ItemGroup>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
@@ -117,10 +117,13 @@
     <BundleResource Include="Resources\Fonts\winjs-symbols.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.1.0-beta.84" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-beta.84" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+    <PackageReference Include="Uno.Core">
+      <Version>4.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/ExtendedSlashScreen.Uno.Samples.iOS.csproj
@@ -13,6 +13,7 @@
     </NuGetPackageImportStamp>
     <ResourcesDirectory>..\ExtendedSlashScreen.Uno.Samples.Shared\Strings</ResourcesDirectory>
     <ProvisioningType>automatic</ProvisioningType>
+    <MtouchSdkVersion>15.0</MtouchSdkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/Info.plist
+++ b/src/samples/ExtendedSlashScreen.Uno.Samples/ExtendedSlashScreen.Uno.Samples.iOS/Info.plist
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>13.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
@@ -46,7 +46,7 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>UILaunchImageMinimumOSVersion</key>
-	<string>9.0</string>
+	<string>13.0</string>
 	<key>UILaunchImageOrientation</key>
 	<string>Portrait</string>
 	<key>UILaunchImageSize</key>


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue


## Other information
iOS samples are not deploying because "The build was cancelled because verification of iOS environment is running. Please try again in a moment."

