### PR TITLE
feat: Add support for Android 12 splash screen visual.

### DIFF
--- a/ExtendedSplashScreen.sln
+++ b/ExtendedSplashScreen.sln
@@ -267,8 +267,6 @@ Global
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|NuGet.ActiveCfg = Debug|Any CPU
-		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|NuGet.Build.0 = Debug|Any CPU
-		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|NuGet.Deploy.0 = Debug|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|Simulator.ActiveCfg = Debug|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|Simulator.Build.0 = Debug|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Debug|Simulator.Deploy.0 = Debug|Any CPU
@@ -301,8 +299,6 @@ Global
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|NuGet.ActiveCfg = Release|Any CPU
-		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|NuGet.Build.0 = Release|Any CPU
-		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|NuGet.Deploy.0 = Release|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|Simulator.ActiveCfg = Release|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|Simulator.Build.0 = Release|Any CPU
 		{1232D032-21D8-4302-9173-8AAB5ACF2130}.Release|Simulator.Deploy.0 = Release|Any CPU
@@ -678,8 +674,6 @@ Global
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|iPhoneSimulator.Build.0 = Debug|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|iPhoneSimulator.Deploy.0 = Debug|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|NuGet.ActiveCfg = Debug|x64
-		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|NuGet.Build.0 = Debug|x64
-		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|NuGet.Deploy.0 = Debug|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|Simulator.ActiveCfg = Debug|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|Simulator.Build.0 = Debug|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Debug|Simulator.Deploy.0 = Debug|x64
@@ -712,8 +706,6 @@ Global
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|iPhoneSimulator.Build.0 = Release|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|iPhoneSimulator.Deploy.0 = Release|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|NuGet.ActiveCfg = Release|x64
-		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|NuGet.Build.0 = Release|x64
-		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|NuGet.Deploy.0 = Release|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|Simulator.ActiveCfg = Release|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|Simulator.Build.0 = Release|x64
 		{F8BEE443-3830-4628-820C-A54634AB9DB5}.Release|Simulator.Deploy.0 = Release|x64
@@ -792,7 +784,6 @@ Global
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|NuGet.ActiveCfg = Debug|Any CPU
-		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|NuGet.Build.0 = Debug|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|Simulator.ActiveCfg = Debug|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|Simulator.Build.0 = Debug|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Debug|UAP.ActiveCfg = Debug|Any CPU
@@ -815,7 +806,6 @@ Global
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|NuGet.ActiveCfg = Release|Any CPU
-		{68966FCA-23CB-4C08-B477-365880435B29}.Release|NuGet.Build.0 = Release|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|Simulator.ActiveCfg = Release|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|Simulator.Build.0 = Release|Any CPU
 		{68966FCA-23CB-4C08-B477-365880435B29}.Release|UAP.ActiveCfg = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ Then, all you need to do is to set the style.
 </Style>
 ```
 
+## Android 12+
+The native splash screen behavior changes starting at Android 12.
+See [reference](https://developer.android.com/develop/ui/views/launch/splash-screen).
+
+`ExtendedSplashScreen` supports the Android 12+ behavior.
+You need to add the following code in your MainActivity.cs to override the default behavior.
+```csharp
+public sealed class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+	protected override void OnCreate(Bundle bundle)
+	{
+		// Handle the splash screen transition.
+		Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+
+		// It's important to call base.OnCreate AFTER setting ExtendedSplashScreen.AndroidSplashScreen.
+		base.OnCreate(bundle);
+	}
+}
+```
+
+Note that when you run your app in debug from Visual Studio (or other IDEs), the new SplashScreen icon doesn't show.
+It shows when you run the app from the launcher (even debug builds).
+
 ## Features
 
 {More details/listing of features of the project}

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -3,11 +3,6 @@
     include:
     - master
 
-resources:
-   containers:
-     - container: windows
-       image: nventive/vs_build-tools:17.2.5
-
 variables:
 - name: NUGET_VERSION
   value: 6.2.0
@@ -19,9 +14,6 @@ variables:
   value: ExtendedSplashScreen.sln
 - name: IsReleaseBranch # Should this branch name use the release stage
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
-# Pool names
-- name: windowsPoolName
-  value: 'windows 2022'
 
 stages:
 - stage: Build
@@ -36,7 +28,7 @@ stages:
           GeneratePackageOnBuild: true
 
     pool:
-      name: $(windowsPoolName)
+      vmImage: 'windows-2022'
 
     variables:
     - name: PackageOutputPath # Path where nuget packages will be copied to.
@@ -44,8 +36,6 @@ stages:
 
     workspace:
       clean: all # Cleanup the workspaca before starting
-
-    container: windows
 
     steps:
     - template: stage-build.yml
@@ -57,7 +47,7 @@ stages:
   - job: Publish_NuGet_External
 
     pool:
-      name: $(windowsPoolName)
+      vmImage: 'windows-2022'
 
     workspace:
       clean: all # Cleanup the workspaca before starting

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.3.0
+next-version: 0.4.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
+++ b/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
@@ -38,6 +38,10 @@
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.1.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0-android'">
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.0.3" />
+  </ItemGroup>
+
   <ItemGroup>
     <!--Microsoft.SourceLink.GitHub is needed for Source Link support -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
+++ b/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid12.0;monoandroid13.0;uap10.0.19041;net472</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<Authors>nventive</Authors>
@@ -42,6 +42,10 @@
 	<ItemGroup>
 		<!--Microsoft.SourceLink.GitHub is needed for Source Link support -->
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'monoandroid12.0' or '$(TargetFramework)' == 'monoandroid13.0'">
+	  <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.0.3" />
 	</ItemGroup>
 	
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uwp.cs
+++ b/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uwp.cs
@@ -46,7 +46,7 @@ namespace Nventive.ExtendedSplashScreen
 			}
 			catch (Exception e)
 			{
-				typeof(ExtendedSplashScreen).Log().LogError(0, e, "Error while getting native splash screen.");
+				Logger.LogError(0, e, "Error while getting native splash screen.");
 			}
 
 			void PositionImage()

--- a/src/library/Shared/Implementations/ExtendedSplashScreen.Android.cs
+++ b/src/library/Shared/Implementations/ExtendedSplashScreen.Android.cs
@@ -1,46 +1,159 @@
 ﻿#if __ANDROID__
 using Android.App;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
 using Microsoft.Extensions.Logging;
 using System;
-using Uno.Extensions;
-using Uno.Logging;
 using Uno.UI;
-using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 #if WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using UnoCanvas = Microsoft.UI.Xaml.Controls.Canvas;
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using UnoCanvas = Windows.UI.Xaml.Controls.Canvas;
 #endif
 
 namespace Nventive.ExtendedSplashScreen
 {
+	[Preserve(AllMembers=true)]
 	public partial class ExtendedSplashScreen
 	{
-		private FrameworkElement GetNativeSplashScreen(SplashScreen splashScreen)
+		private static ExtendedSplashScreen _instance;
+		private static Bitmap _splashBitmap;
+		private static AndroidX.Core.SplashScreen.SplashScreen _androidSplashScreen;
+
+		/// <summary>
+		/// Gets or sets the Android SplashScreen.<br/>
+		/// Set this in your the OnCreate of your Activity using the result from InstallSplashScreen before calling base.OnCreate.<br/>
+		/// Setting this changes the behavior of the ExtendedSplashScreen to use the Android 12+ native SplashScreen (instead of the WindowBackground).
+		/// <example>
+		/// <code>
+		/// protected override void OnCreate(Bundle bundle)
+		/// { 
+		///	    // Handle the splash screen transition.
+		///	    ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+		/// 
+		///	    base.OnCreate(bundle);
+		///	}
+		///	</code>
+		/// </example>
+		/// </summary>
+		public static AndroidX.Core.SplashScreen.SplashScreen AndroidSplashScreen
+		{
+			get => _androidSplashScreen;
+			set
+			{
+				_androidSplashScreen = value;
+				_androidSplashScreen.ExitAnimation += OnExitAnimation;
+			}
+		}
+
+		private static void OnExitAnimation(object sender, AndroidX.Core.SplashScreen.SplashScreen.ExitAnimationEventArgs e)
+		{
+			Trace("Started OnExitAnimation.");
+
+			_splashBitmap = GetBitmapFromView(e.SplashScreenViewProvider.View);
+
+			if (_instance._splashScreenPresenter != null)
+			{
+				
+				Trace("Setting ExtendedSplashScreen content.");
+				_instance._splashScreenPresenter.Content = _instance.GetNativeSplashScreen(null);
+				Trace("Set ExtendedSplashScreen content. Removing native SplashScreen.");
+
+				// Remove the native splash now that we've set the extended one.
+				e.SplashScreenViewProvider.Remove();
+				Trace("Removed native SplashScreen.");
+				
+			}
+			Trace("Finished OnExitAnimation.");
+		}
+
+		public static Bitmap GetBitmapFromView(View view)
+		{
+			Trace("GetBitmapFromView: Generating bitmap.");
+
+			//Define a bitmap with the same size as the view
+			Bitmap returnedBitmap = Bitmap.CreateBitmap(view.Width, view.Height, Bitmap.Config.Argb8888);
+
+			Trace("GetBitmapFromView: Generating canvas.");
+
+			//Bind a canvas to it
+			Android.Graphics.Canvas canvas = new Android.Graphics.Canvas(returnedBitmap);
+			//Get the view's background
+
+			Drawable bgDrawable = view.Background;
+			if (bgDrawable != null)
+			{
+				Trace("GetBitmapFromView: Drawing background.");
+
+				//has background drawable, then draw it on the canvas
+				bgDrawable.Draw(canvas);
+			}
+			else
+			{
+				Trace("GetBitmapFromView: Drawing white background.");
+
+				//does not have background drawable, then draw white background on the canvas
+				canvas.DrawColor(Android.Graphics.Color.White);
+			}
+
+			Trace("GetBitmapFromView: Drawing view.");
+
+			// draw the view on the canvas
+			view.Draw(canvas);
+
+			Trace("GetBitmapFromView: Generated bitmap.");
+
+			//return the bitmap
+			return returnedBitmap;
+		}
+
+		private FrameworkElement GetNativeSplashScreen(Windows.ApplicationModel.Activation.SplashScreen splashScreen)
 		{
 			try
 			{
-				var activity = ContextHelper.Current as Activity;
+				if (AndroidSplashScreen != null && _splashBitmap == null)
+				{
+					Trace("AndroidSplashScreen is not null. Waiting for native splashscreen animation exit to get the native view.");
+					
+					_instance = this;
+					return null;
+				}
 
-				// Get the theme's windowBackground (which we use as splash screen)
-				var attribute = new Android.Util.TypedValue();
-				activity?.Theme.ResolveAttribute(Android.Resource.Attribute.WindowBackground, attribute, true);
-				var windowBackgroundResourceId = attribute.ResourceId;
+				var activity = ContextHelper.Current as Activity;
 
 				// Get the splash screen size
 				var splashScreenSize = GetSplashScreenSize(activity);
-				
-				// Create the splash screen surface
-				var splashView = new Android.Views.View(activity);
-				splashView.SetBackgroundResource(attribute.ResourceId);
+
+				var imageView = new ImageView(activity);
+				imageView.SetImageBitmap(_splashBitmap);
+				View splashView = imageView;
+
+				if (splashView == null)
+				{
+					Trace("Android 12 splash screen bitmap unavailable. Falling back to default behavior.");
+					
+					// Get the theme's windowBackground (which we use as splash screen)
+					var attribute = new Android.Util.TypedValue();
+					activity?.Theme.ResolveAttribute(Android.Resource.Attribute.WindowBackground, attribute, true);
+					var windowBackgroundResourceId = attribute.ResourceId;
+
+					// Create the splash screen surface
+					splashView = new Android.Views.View(activity);
+					splashView.SetBackgroundResource(attribute.ResourceId);
+				}
 
 				// We use a Canvas to ensure it's clipped but not resized (important when device has soft-keys)
-				var element = new Canvas
+				var element = new UnoCanvas
 				{
 					// We set a background to prevent touches from going through
 					Background = SolidColorBrushHelper.Transparent,
@@ -60,7 +173,7 @@ namespace Nventive.ExtendedSplashScreen
 			}
 			catch (Exception e)
 			{
-				typeof(ExtendedSplashScreen).Log().LogError(0, e, "Error while getting native splash screen.");
+				Logger.LogError(0, e, "Error while getting native splash screen.");
 
 				return null;
 			}
@@ -84,6 +197,14 @@ namespace Nventive.ExtendedSplashScreen
 				ViewHelper.PhysicalToLogicalPixels(physicalDisplaySize.X),
 				ViewHelper.PhysicalToLogicalPixels(physicalDisplaySize.Y)
 			);
+		}
+
+		private static void Trace(string message)
+		{
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTrace(message);
+			}
 		}
 	}
 }

--- a/src/library/Shared/Implementations/ExtendedSplashScreen.cs
+++ b/src/library/Shared/Implementations/ExtendedSplashScreen.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
 using Windows.ApplicationModel.Activation;
 #if WINUI
 using Microsoft.UI.Xaml;
@@ -26,8 +28,14 @@ namespace Nventive.ExtendedSplashScreen
 		private const string DismissedStateName = "Dismissed";
 
 		private bool _isDismissed;
+		private ContentPresenter _splashScreenPresenter;
 
 		public SplashScreen SplashScreen { get; set; }
+
+		/// <summary>
+		/// Gets or sets the logger for this class.
+		/// </summary>
+		public static ILogger Logger { get; set; } = typeof(ExtendedSplashScreen).Log();
 
 		/// <summary>
 		/// Alternative to <see cref="SplashScreen"/>.
@@ -48,7 +56,8 @@ namespace Nventive.ExtendedSplashScreen
 
 			if (GetTemplateChild(SplashScreenPresenterPartName) is ContentPresenter splashScreenPresenter)
 			{
-				splashScreenPresenter.Content = GetNativeSplashScreen(SplashScreen);
+				_splashScreenPresenter = splashScreenPresenter;
+				_splashScreenPresenter.Content = GetNativeSplashScreen(SplashScreen);
 			}
 
 			UpdateSplashScreenState(useTransitions: false);

--- a/src/library/Shared/Implementations/ExtendedSplashScreen.iOS.cs
+++ b/src/library/Shared/Implementations/ExtendedSplashScreen.iOS.cs
@@ -52,7 +52,7 @@ namespace Nventive.ExtendedSplashScreen
 			}
 			catch (Exception e)
 			{
-				typeof(ExtendedSplashScreen).Log().LogError(0, e, "Error while getting native splash screen.");
+				Logger.LogError(0, e, "Error while getting native splash screen.");
 
 				return null;
 			}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

On Android 12, the extended splash screen is different than the native one.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The library now supports having the Android 12+ native splash screen UI in the `ExtendedSplashScreen`.

### Before and After
In the following videos, the ExtendedSplashScreen is when we see a loading wheel.

#### Before
https://user-images.githubusercontent.com/39710855/221656890-82cd638b-af33-4716-be59-4d627be7ec2e.mp4

#### After
https://user-images.githubusercontent.com/39710855/221656902-32b45c45-524e-447c-9120-0c677914a8ed.mp4


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

