### PR TITLE
fix: Specify the .Net SDK version so that hosted agents use .Net 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+﻿{
+	// We want to use .Net 6 and not 7 because that causes problems with apps built using .Net 6.
+	"sdk": {
+		"version": "6.0.300",
+		"rollForward": "latestFeature"
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

The iOS packages contains code built with .Net 7 which is incompatible with apps built using .Net 6.
https://github.com/unoplatform/uno/discussions/11518

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The package should now be built using .Net 6.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

