### PR TITLE
Revert build agent changes to fix the iOS regression

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -3,6 +3,11 @@
     include:
     - master
 
+resources:
+   containers:
+     - container: windows
+       image: nventive/vs_build-tools:17.2.5
+
 variables:
 - name: NUGET_VERSION
   value: 6.2.0
@@ -14,6 +19,9 @@ variables:
   value: ExtendedSplashScreen.sln
 - name: IsReleaseBranch # Should this branch name use the release stage
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
+# Pool names
+- name: windowsPoolName
+  value: 'windows 2022'
 
 stages:
 - stage: Build
@@ -28,7 +36,7 @@ stages:
           GeneratePackageOnBuild: true
 
     pool:
-      vmImage: 'windows-2022'
+      name: $(windowsPoolName)
 
     variables:
     - name: PackageOutputPath # Path where nuget packages will be copied to.
@@ -36,6 +44,8 @@ stages:
 
     workspace:
       clean: all # Cleanup the workspaca before starting
+
+    container: windows
 
     steps:
     - template: stage-build.yml
@@ -47,7 +57,7 @@ stages:
   - job: Publish_NuGet_External
 
     pool:
-      vmImage: 'windows-2022'
+      name: $(windowsPoolName)
 
     workspace:
       clean: all # Cleanup the workspaca before starting

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
-assembly-versioning-scheme: MajorMinorPatch
+﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.4.0
+next-version: 0.5.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -61,7 +61,9 @@
     restoreNugetPackages: false
     logProjectEvents: false
     createLogFile: false
-    msbuildArguments: /p:PackageVersion=$(GitVersion.SemVer) # Set the version of the packages, will have no effect on application projects (Heads).
+    msbuildArguments: > # Set the version of the packages, will have no effect on application projects (Heads).
+      /p:PackageVersion=$(GitVersion.SemVer) 
+      /bl:$(build.artifactstagingdirectory)/build.binlog
 
 - task: VSTest@2
   displayName: 'Run tests'

--- a/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
+++ b/src/library/ExtendedSplashScreen.Uno/ExtendedSplashScreen.Uno.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid12.0;monoandroid13.0;uap10.0.19041;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid12.0;uap10.0.19041;net472</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<Authors>nventive</Authors>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- The iOS package is not compatible with apps built with .Net 6 SDK.
- The nuget package targets monoandroid13.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- The iOS package should be compatible with apps built with .Net 6 SDK.
- The nuget package does not targets monoandroid13.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

