### PR TITLE
fix: implemented workaround for Uno.Toolkit.UI error

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-﻿{
-	// We want to use .Net 6 and not 7 because that causes problems with apps built using .Net 6.
-	"sdk": {
-		"version": "6.0.300",
-		"rollForward": "latestFeature"
-	}
-}

--- a/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
+++ b/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
@@ -65,4 +65,5 @@
   </ItemGroup>
 
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+	<Import Project="winappsdk-workaround.targets" />
 </Project>

--- a/src/library/ExtendedSplashScreen.Uno.WinUI/winappsdk-workaround.targets
+++ b/src/library/ExtendedSplashScreen.Uno.WinUI/winappsdk-workaround.targets
@@ -1,0 +1,27 @@
+<Project>
+	<!--
+		Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file:
+			> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5097,5):
+			> error MSB3030: Could not copy the file "D:\a\1\s\src\Uno.Toolkit.UI\obj\Uno.Toolkit.WinUI\Release\net7.0-windows10.0.19041\Controls\AutoLayout\AutoLayout.xbf" because it was not found.
+			> [D:\a\1\s\src\Uno.Toolkit.RuntimeTests\Uno.Toolkit.RuntimeTests.WinUI.csproj]
+		Just <Import /> this file into the winui project appearing in the `[]` bracket.
+	-->
+	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
+		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
+		<ItemGroup>
+			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
+			<PackagingOutputs Remove="@(_OtherPriFiles)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
+		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
+		<ItemGroup>
+			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />
+			<_ReferenceRelatedPaths Remove="@(_OtherPriFiles1)" />
+
+			<_OtherPriFiles2 Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.pri' and ('%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(ReferenceCopyLocalPaths.NugetSourceType)'=='Package')" />
+			<ReferenceCopyLocalPaths Remove="@(_OtherPriFiles2)" />
+		</ItemGroup>
+	</Target>
+</Project>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe: workaround

## What is the current behavior?
Currently when upgrading a project to Uno 5+ the following message is displayed when using this package:
![image](https://github.com/nventive/Chinook.DataLoader/assets/104783204/3a8e24cc-8998-428f-84fd-0a145d011501)

## What is the new behavior?
Workaround implemented avoids including Uno.Toolkit.UI XBFs in the PRI file

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [ ] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
Currently a WIP as the investigation continues to locate all the packages that cause this exception to be thrown
