### PR TITLE
fix(76): Prevent the creation of 0-sized bitmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ public sealed class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 Note that when you run your app in debug from Visual Studio (or other IDEs), the new SplashScreen icon doesn't show.
 It shows when you run the app from the launcher (even debug builds).
 
+## Trace Logs
+You can enable trace logs on the `Nventive.ExtendedSplashScreen` namespace to get more information about the runtime behavior.
+
+You can override the logger via `ExtendedSplashScreen.Logger`.
+By default, one is created using the `AmbientLoggerFactory` from the `Uno.Core.Extensions.Logging.Singleton` package.
+
+
 ## Changelog
 
 Please consult the [CHANGELOG](CHANGELOG.md) for more information about version


### PR DESCRIPTION
GitHub Issue: Fixes #76 
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

There is no validation on the bitmap dimensions when creating the copy of the native splash screen.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

There is a validation on the bitmap dimensions to avoid creating a 0-sized bitmap.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
  - README.md was reviewed.
  - [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) was updated (if you introduced a breaking change).
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->