### PR TITLE
chore: remove unused NuGet package Uno.SourceGenerationTasks

### DIFF
--- a/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
+++ b/src/library/ExtendedSplashScreen.Uno.WinUI/ExtendedSplashScreen.Uno.WinUI.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.WinUI" Version="5.0.19" />
-    <PackageReference Include="Uno.SourceGenerationTasks" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0-android'">


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Uno.SourceGenerationTasks is referenced.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Uno.SourceGenerationTasks is not referenced.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
  - README.md was reviewed.
  - [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) was updated (if you introduced a breaking change).
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->